### PR TITLE
RC-37682 [Azure] Added CloudServices into check to remove the meterName

### DIFF
--- a/pkg/cloud/azure/provider.go
+++ b/pkg/cloud/azure/provider.go
@@ -978,7 +978,7 @@ func convertMeterToPricings(info commerce.MeterInfo, regions map[string]string, 
 		return nil, nil
 	}
 
-	if strings.Contains(meterSubCategory, "Cloud Services") {
+	if strings.Contains(meterSubCategory, "Cloud Services") || strings.Contains(meterSubCategory, "CloudServices") {
 		// This meter doesn't correspond to any pricings.
 		return nil, nil
 	}


### PR DESCRIPTION
Msft returns CloudServices incase of Standard_E2as_v5 pricing API respone, while for others it returns Cloud Services. Added CloudServices into check to remove the meter. (#17)
